### PR TITLE
Fix not enough arguments in Delete call

### DIFF
--- a/util.go
+++ b/util.go
@@ -82,7 +82,7 @@ func SendRequest(u string, method int, sess *napping.Session, pload interface{},
 	case PATCH:
 		resp, err = sess.Patch(u, &pload, &res, &e)
 	case DELETE:
-		resp, err = sess.Delete(u, &res, &e)
+		resp, err = sess.Delete(u, nil, &res, &e)
 	}
 
 	if err != nil {


### PR DESCRIPTION
It was failing to build with:

```
./util.go:85: not enough arguments in call to sess.Delete
```
