### PR TITLE
Add NewInsecure() function for using non https requests

### DIFF
--- a/f5/client-ssl.go
+++ b/f5/client-ssl.go
@@ -67,7 +67,7 @@ type LBClientSsls struct {
 
 func (f *Device) ShowClientSsls() (error, *LBClientSsls) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl"
 	res := LBClientSsls{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -81,7 +81,7 @@ func (f *Device) ShowClientSsls() (error, *LBClientSsls) {
 func (f *Device) ShowClientSsl(cname string) (error, *LBClientSsl) {
 
 	client := strings.Replace(cname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
 	res := LBClientSsl{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -95,7 +95,7 @@ func (f *Device) ShowClientSsl(cname string) (error, *LBClientSsl) {
 
 func (f *Device) AddClientSsl(body *json.RawMessage) (error, *LBClientSsl) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl"
 	res := LBClientSsl{}
 
 	err, _ := f.sendRequest(u, POST, &body, &res)
@@ -110,7 +110,7 @@ func (f *Device) AddClientSsl(body *json.RawMessage) (error, *LBClientSsl) {
 func (f *Device) UpdateClientSsl(cname string, body *json.RawMessage) (error, *LBClientSsl) {
 
 	client := strings.Replace(cname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
 	res := LBClientSsl{}
 
 	// put the request
@@ -126,7 +126,7 @@ func (f *Device) UpdateClientSsl(cname string, body *json.RawMessage) (error, *L
 func (f *Device) DeleteClientSsl(cname string) (error, *Response) {
 
 	client := strings.Replace(cname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/client-ssl/" + client
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/device.go
+++ b/f5/device.go
@@ -14,7 +14,7 @@ type LBDeviceState struct {
 
 func (f *Device) ShowDevice() (error, *LBDeviceRef) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/cm/device"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/cm/device"
 	res := LBDeviceRef{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)

--- a/f5/monitor-http.go
+++ b/f5/monitor-http.go
@@ -34,7 +34,7 @@ type LBMonitorHttpRef struct {
 
 func (f *Device) ShowMonitorsHttp() (error, *LBMonitorHttpRef) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/monitor/http"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/monitor/http"
 	res := LBMonitorHttpRef{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -49,7 +49,7 @@ func (f *Device) ShowMonitorsHttp() (error, *LBMonitorHttpRef) {
 func (f *Device) ShowMonitorHttp(vname string) (error, *LBMonitorHttp) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname + "?expandSubcollections=true"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname + "?expandSubcollections=true"
 	res := LBMonitorHttp{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -63,7 +63,7 @@ func (f *Device) ShowMonitorHttp(vname string) (error, *LBMonitorHttp) {
 
 func (f *Device) AddMonitorHttp(body *json.RawMessage) (error, *LBMonitorHttp) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/monitor/http"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/monitor/http"
 	res := LBMonitorHttp{}
 
 	// post the request
@@ -78,7 +78,7 @@ func (f *Device) AddMonitorHttp(body *json.RawMessage) (error, *LBMonitorHttp) {
 func (f *Device) UpdateMonitorHttp(vname string, body *json.RawMessage) (error, *LBMonitorHttp) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname
 	res := LBMonitorHttp{}
 
 	// put the request
@@ -94,7 +94,7 @@ func (f *Device) UpdateMonitorHttp(vname string, body *json.RawMessage) (error, 
 func (f *Device) DeleteMonitorHttp(vname string) (error, *Response) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/monitor/http/" + vname
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/node.go
+++ b/f5/node.go
@@ -104,7 +104,7 @@ type LBNodeStats struct {
 
 func (f *Device) ShowNodes() (error, *LBNodes) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node"
 	res := LBNodes{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -118,9 +118,9 @@ func (f *Device) ShowNodes() (error, *LBNodes) {
 
 func (f *Device) ShowNode(nname string) (error, *LBNode) {
 
-	//u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/~" + partition + "~" + pname + "?expandSubcollections=true"
+	//u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/~" + partition + "~" + pname + "?expandSubcollections=true"
 	node := strings.Replace(nname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
 	res := LBNode{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -135,7 +135,7 @@ func (f *Device) ShowNode(nname string) (error, *LBNode) {
 func (f *Device) ShowNodeStats(nname string) (error, *LBNodeStats) {
 
 	node := strings.Replace(nname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node/" + node + "/stats"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node/" + node + "/stats"
 	res := LBNodeStats{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -149,7 +149,7 @@ func (f *Device) ShowNodeStats(nname string) (error, *LBNodeStats) {
 
 func (f *Device) AddNode(body *json.RawMessage) (error, *LBNode) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node"
 	res := LBNode{}
 
 	// post the request
@@ -165,7 +165,7 @@ func (f *Device) AddNode(body *json.RawMessage) (error, *LBNode) {
 func (f *Device) UpdateNode(nname string, body *json.RawMessage) (error, *LBNode) {
 
 	node := strings.Replace(nname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
 	res := LBNode{}
 
 	// put the request
@@ -181,7 +181,7 @@ func (f *Device) UpdateNode(nname string, body *json.RawMessage) (error, *LBNode
 func (f *Device) DeleteNode(nname string) (error, *Response) {
 
 	node := strings.Replace(nname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node/" + node
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/policy.go
+++ b/f5/policy.go
@@ -73,7 +73,7 @@ type LBPolicies struct {
 
 func (f *Device) ShowPolicies() (error, *LBPolicies) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy"
 	res := LBPolicies{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -88,7 +88,7 @@ func (f *Device) ShowPolicies() (error, *LBPolicies) {
 func (f *Device) ShowPolicy(pname string) (error, *LBPolicy) {
 
 	policy := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy + "?expandSubcollections=true"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy + "?expandSubcollections=true"
 	res := LBPolicy{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -102,7 +102,7 @@ func (f *Device) ShowPolicy(pname string) (error, *LBPolicy) {
 
 func (f *Device) AddPolicy(body *json.RawMessage) (error, *LBPolicy) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy"
 	res := LBPolicy{}
 
 	// post the request
@@ -118,7 +118,7 @@ func (f *Device) AddPolicy(body *json.RawMessage) (error, *LBPolicy) {
 func (f *Device) UpdatePolicy(pname string, body *json.RawMessage) (error, *LBPolicy) {
 
 	policy := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy
 	res := LBPolicy{}
 
 	// put the request
@@ -133,9 +133,9 @@ func (f *Device) UpdatePolicy(pname string, body *json.RawMessage) (error, *LBPo
 
 func (f *Device) DeletePolicy(pname string) (error, *Response) {
 
-	//u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy/~" + partition + "~" + pname + "?expandSubcollections=true"
+	//u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy/~" + partition + "~" + pname + "?expandSubcollections=true"
 	policy := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/policy/" + policy
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/pool.go
+++ b/f5/pool.go
@@ -131,7 +131,7 @@ type LBPoolStats struct {
 
 func (f *Device) ShowPools() (error, *LBPools) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool"
 	res := LBPools{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -146,7 +146,7 @@ func (f *Device) ShowPools() (error, *LBPools) {
 func (f *Device) ShowPool(pname string) (error, *LBPool) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "?expandSubcollections=true"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "?expandSubcollections=true"
 	res := LBPool{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -161,7 +161,7 @@ func (f *Device) ShowPool(pname string) (error, *LBPool) {
 func (f *Device) ShowPoolStats(pname string) (error, *LBPoolStats) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/stats"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/stats"
 	res := LBPoolStats{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -176,7 +176,7 @@ func (f *Device) AddPool(body *json.RawMessage) (error, *LBPool) {
 	// we use json.RawMessage so we can modify the input file without using a struct
 	// use of a struct will send all available fields, some of which can't be modified
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool"
 	res := LBPool{}
 
 	// post the request
@@ -192,7 +192,7 @@ func (f *Device) AddPool(body *json.RawMessage) (error, *LBPool) {
 func (f *Device) UpdatePool(pname string, body *json.RawMessage) (error, *LBPool) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool
 	res := LBPool{}
 
 	// put the request
@@ -208,7 +208,7 @@ func (f *Device) UpdatePool(pname string, body *json.RawMessage) (error, *LBPool
 func (f *Device) DeletePool(pname string) (error, *Response) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)
@@ -223,7 +223,7 @@ func (f *Device) DeletePool(pname string) (error, *Response) {
 func (f *Device) ShowPoolMembers(pname string) (error, *LBPoolMembers) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
 	res := LBPoolMembers{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -238,7 +238,7 @@ func (f *Device) ShowPoolMembers(pname string) (error, *LBPoolMembers) {
 func (f *Device) AddPoolMembers(pname string, body *json.RawMessage) (error, *LBPoolMembers) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
 	res := LBPoolMembers{}
 
 	// post the request
@@ -254,7 +254,7 @@ func (f *Device) AddPoolMembers(pname string, body *json.RawMessage) (error, *LB
 func (f *Device) UpdatePoolMembers(pname string, body *json.RawMessage) (error, *LBPoolMembers) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
 	res := LBPoolMembers{}
 
 	// put the request
@@ -270,7 +270,7 @@ func (f *Device) UpdatePoolMembers(pname string, body *json.RawMessage) (error, 
 func (f *Device) DeletePoolMembers(pname string) (error, *Response) {
 
 	pool := strings.Replace(pname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members"
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)
@@ -287,7 +287,7 @@ func (f *Device) OnlinePoolMember(pname string, mname string) (error, *Response)
 	pmember := strings.Replace(mname, "/", "~", -1)
 	pool := strings.Replace(pname, "/", "~", -1)
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
 	res := json.RawMessage{}
 
 	/*
@@ -312,7 +312,7 @@ func (f *Device) OfflinePoolMember(pname string, mname string) (error, *Response
 	pmember := strings.Replace(mname, "/", "~", -1)
 	pool := strings.Replace(pname, "/", "~", -1)
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
 	res := json.RawMessage{}
 
 	/*
@@ -336,7 +336,7 @@ func (f *Device) OfflinePoolMemberForced(pname string, mname string) (error, *Re
 	pmember := strings.Replace(mname, "/", "~", -1)
 	pool := strings.Replace(pname, "/", "~", -1)
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/" + pool + "/members/" + pmember
 	res := json.RawMessage{}
 
 	/*

--- a/f5/profile.go
+++ b/f5/profile.go
@@ -16,7 +16,7 @@ type LBProfiles struct {
 
 func (f *Device) ShowProfiles() (error, *LBProfiles) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile"
 	res := LBProfiles{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -30,7 +30,7 @@ func (f *Device) ShowProfiles() (error, *LBProfiles) {
 
 func (f *Device) ShowProfile(profile string) (error, *json.RawMessage) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/" + profile
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/" + profile
 	res := json.RawMessage{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -46,7 +46,7 @@ func (f *Device) ShowProfile(profile string) (error, *json.RawMessage) {
 func (f *Device) ShowServerSsl(sname string) (error, *LBServerSsl) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := LBServerSsl{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -60,7 +60,7 @@ func (f *Device) ShowServerSsl(sname string) (error, *LBServerSsl) {
 
 func (f *Device) AddServerSsl(body *json.RawMessage) (error, *LBServerSsl) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
 	res := LBServerSsl{}
 
 	// post the request
@@ -76,7 +76,7 @@ func (f *Device) AddServerSsl(body *json.RawMessage) (error, *LBServerSsl) {
 func (f *Device) UpdateServerSsl(sname string, body *json.RawMessage) (error, *LBServerSsl) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := LBServerSsl{}
 
 	// put the request
@@ -92,7 +92,7 @@ func (f *Device) UpdateServerSsl(sname string, body *json.RawMessage) (error, *L
 func (f *Device) DeleteServerSsl(sname string) (error, *Response) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/rule.go
+++ b/f5/rule.go
@@ -62,7 +62,7 @@ type LBRuleStats struct {
 
 func (f *Device) ShowRules() (error, *LBRules) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule"
 	res := LBRules{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -77,7 +77,7 @@ func (f *Device) ShowRules() (error, *LBRules) {
 func (f *Device) ShowRule(rname string) (error, *LBRule) {
 
 	rule := strings.Replace(rname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
 	res := LBRule{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -92,7 +92,7 @@ func (f *Device) ShowRule(rname string) (error, *LBRule) {
 func (f *Device) ShowRuleStats(rname string) (error, *LBRuleStats) {
 
 	rule := strings.Replace(rname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule + "/stats"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule + "/stats"
 	res := LBRuleStats{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -106,7 +106,7 @@ func (f *Device) ShowRuleStats(rname string) (error, *LBRuleStats) {
 
 func (f *Device) AddRule(body *json.RawMessage) (error, *LBRule) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule"
 	res := LBRule{}
 
 	// post the request
@@ -122,7 +122,7 @@ func (f *Device) AddRule(body *json.RawMessage) (error, *LBRule) {
 func (f *Device) UpdateRule(rname string, body *json.RawMessage) (error, *LBRule) {
 
 	rule := strings.Replace(rname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
 	res := LBRule{}
 
 	// put the request
@@ -138,7 +138,7 @@ func (f *Device) UpdateRule(rname string, body *json.RawMessage) (error, *LBRule
 func (f *Device) DeleteRule(rname string) (error, *Response) {
 
 	rule := strings.Replace(rname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/server-ssl.go
+++ b/f5/server-ssl.go
@@ -53,7 +53,7 @@ type LBServerSsls struct {
 
 func (f *Device) ShowServerSsls() (error, *LBServerSsls) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
 	res := LBServerSsls{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -68,7 +68,7 @@ func (f *Device) ShowServerSsls() (error, *LBServerSsls) {
 func (f *Device) ShowServerSsl(sname string) (error, *LBServerSsl) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := LBServerSsl{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -82,7 +82,7 @@ func (f *Device) ShowServerSsl(sname string) (error, *LBServerSsl) {
 
 func (f *Device) AddServerSsl(body *json.RawMessage) (error, *LBServerSsl) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl"
 	res := LBServerSsl{}
 
 	// post the request
@@ -98,7 +98,7 @@ func (f *Device) AddServerSsl(body *json.RawMessage) (error, *LBServerSsl) {
 func (f *Device) UpdateServerSsl(sname string, body *json.RawMessage) (error, *LBServerSsl) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := LBServerSsl{}
 
 	// put the request
@@ -114,7 +114,7 @@ func (f *Device) UpdateServerSsl(sname string, body *json.RawMessage) (error, *L
 func (f *Device) DeleteServerSsl(sname string) (error, *Response) {
 
 	server := strings.Replace(sname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/profile/server-ssl/" + server
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)

--- a/f5/virtual.go
+++ b/f5/virtual.go
@@ -132,7 +132,7 @@ type LBVirtualStats struct {
 
 func (f *Device) ShowVirtuals() (error, *LBVirtuals) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual"
 	res := LBVirtuals{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -147,7 +147,7 @@ func (f *Device) ShowVirtuals() (error, *LBVirtuals) {
 func (f *Device) ShowVirtual(vname string) (error, *LBVirtual) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname + "?expandSubcollections=true"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname + "?expandSubcollections=true"
 	res := LBVirtual{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -162,7 +162,7 @@ func (f *Device) ShowVirtual(vname string) (error, *LBVirtual) {
 func (f *Device) ShowVirtualStats(vname string) (error, *LBVirtualStats) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname + "/stats"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname + "/stats"
 	res := LBVirtualStats{}
 
 	err, _ := f.sendRequest(u, GET, nil, &res)
@@ -175,7 +175,7 @@ func (f *Device) ShowVirtualStats(vname string) (error, *LBVirtualStats) {
 
 func (f *Device) AddVirtual(virt *json.RawMessage) (error, *LBVirtual) {
 
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual"
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual"
 	res := LBVirtual{}
 
 	// post the request
@@ -191,7 +191,7 @@ func (f *Device) AddVirtual(virt *json.RawMessage) (error, *LBVirtual) {
 func (f *Device) UpdateVirtual(vname string, body *json.RawMessage) (error, *LBVirtual) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname
 	res := LBVirtual{}
 
 	// put the request
@@ -207,7 +207,7 @@ func (f *Device) UpdateVirtual(vname string, body *json.RawMessage) (error, *LBV
 func (f *Device) DeleteVirtual(vname string) (error, *Response) {
 
 	vname = strings.Replace(vname, "/", "~", -1)
-	u := "https://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual/" + vname
 	res := json.RawMessage{}
 
 	err, resp := f.sendRequest(u, DELETE, nil, &res)


### PR DESCRIPTION
Hi, 
this PR adds Proto to the Device struct and  adds a NewInsecure() func which may be used when mocking requests in tests:

```
func testTools(code int, body string) (*httptest.Server, *f5.Device) {

    username = "testuser"
    password = "testpass"
    host = "bigip"
    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
        log.Println(r.URL.Path)
        if r.URL.Path == "/mgmt/shared/authn/login" {
            w.WriteHeader(code)
            w.Header().Set("Content-Type", "application/json")
            fmt.Fprintln(w, `{"token": {"token": "123456789", "expirationMicros": 123456789}}`)
        } else {
            w.WriteHeader(code)
            w.Header().Set("Content-Type", "application/json")
            fmt.Fprintln(w, body)
        }
    }))

    tr := &http.Transport{
        Proxy: func(req *http.Request) (*url.URL, error) {
            return url.Parse(server.URL)
        },
        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
    }
    appliance := f5.NewInsecure(host, username, password, f5.TOKEN)
    appliance.Session.Client.Transport = tr
    return server, appliance
}

func TestGetVirtualServer(t *testing.T) {
    server, client := testTools(200, `
        {"fullPath": "/partition/virtual-server",
         "rules": ["/Common/irule", "/partition/irule"]}
        `)
    defer server.Close()
    _, err := GetVirtualServer("virtual-server", client)
    assert.Nil(t, err)
}
```
