### PR TITLE
Add Raw-ish methods for POST/PUT when iRules contains chars that json…

### DIFF
--- a/f5/f5.go
+++ b/f5/f5.go
@@ -25,7 +25,9 @@ var (
 const (
 	GET = iota
 	POST
+	POSTR
 	PUT
+	PUTR
 	PATCH
 	DELETE
 )
@@ -182,6 +184,28 @@ func (f *Device) sendRequest(u string, method int, pload interface{}, res interf
 		nresp, err = f.Session.Patch(u, &pload, &res, &e)
 	case DELETE:
 		nresp, err = f.Session.Delete(u, nil, &res, &e)
+	case POSTR:
+		r := napping.Request{
+			Method:  "POST",
+			Url:     u,
+			Params: nil,
+			Payload: pload,
+			RawPayload: true,
+			Result:  res,
+			Error:   e,
+		}
+		nresp, err = f.Session.Send(&r)
+	case PUTR:
+		r := napping.Request{
+			Method:  "PUT",
+			Url:     u,
+			Params: nil,
+			Payload: pload,
+			RawPayload: true,
+			Result:  &res,
+			Error:   &e,
+		}
+		nresp, err = f.Session.Send(&r)
 	}
 
 	var resp = Response{Status: nresp.Status(), Message: e.Message}

--- a/f5/rule.go
+++ b/f5/rule.go
@@ -3,6 +3,7 @@ package f5
 import (
 	"encoding/json"
 	"strings"
+	"bytes"
 )
 
 type LBRawValues struct {
@@ -119,6 +120,21 @@ func (f *Device) AddRule(body *json.RawMessage) (error, *LBRule) {
 
 }
 
+func (f *Device) AddRuleRaw(body *bytes.Buffer) (error, *LBRule) {
+
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule"
+	res := LBRule{}
+
+	// post the request
+	err, _ := f.sendRequest(u, POSTR, &body, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+
+}
+
 func (f *Device) UpdateRule(rname string, body *json.RawMessage) (error, *LBRule) {
 
 	rule := strings.Replace(rname, "/", "~", -1)
@@ -127,6 +143,22 @@ func (f *Device) UpdateRule(rname string, body *json.RawMessage) (error, *LBRule
 
 	// put the request
 	err, _ := f.sendRequest(u, PUT, &body, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+
+}
+
+func (f *Device) UpdateRuleRaw(rname string, body *bytes.Buffer) (error, *LBRule) {
+
+	rule := strings.Replace(rname, "/", "~", -1)
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/" + rule
+	res := LBRule{}
+
+	// put the request
+	err, _ := f.sendRequest(u, PUTR, body, &res)
 	if err != nil {
 		return err, nil
 	} else {


### PR DESCRIPTION
… will escape. https://golang.org/src/encoding/json/encode.go#L43. This makes BigIP unable to verify the the TCL code

This fixes #12 
