### PR TITLE
Fixing error handeling in sendRequest if connection fails.

### DIFF
--- a/f5/f5.go
+++ b/f5/f5.go
@@ -48,7 +48,7 @@ type Device struct {
 	Session    napping.Session
 	AuthToken  authToken
 	AuthMethod AuthMethod
-	Proto string
+	Proto      string
 }
 
 type Response struct {
@@ -186,29 +186,33 @@ func (f *Device) sendRequest(u string, method int, pload interface{}, res interf
 		nresp, err = f.Session.Delete(u, nil, &res, &e)
 	case POSTR:
 		r := napping.Request{
-			Method:  "POST",
-			Url:     u,
-			Params: nil,
-			Payload: pload,
+			Method:     "POST",
+			Url:        u,
+			Params:     nil,
+			Payload:    pload,
 			RawPayload: true,
-			Result:  res,
-			Error:   e,
+			Result:     res,
+			Error:      e,
 		}
 		nresp, err = f.Session.Send(&r)
 	case PUTR:
 		r := napping.Request{
-			Method:  "PUT",
-			Url:     u,
-			Params: nil,
-			Payload: pload,
+			Method:     "PUT",
+			Url:        u,
+			Params:     nil,
+			Payload:    pload,
 			RawPayload: true,
-			Result:  &res,
-			Error:   &e,
+			Result:     &res,
+			Error:      &e,
 		}
 		nresp, err = f.Session.Send(&r)
 	}
 
-	var resp = Response{Status: nresp.Status(), Message: e.Message}
+	var resp Response
+	if nresp != nil {
+		resp = Response{Status: nresp.Status(), Message: e.Message}
+	}
+
 	if err != nil {
 		return err, &resp
 	}
@@ -298,7 +302,7 @@ func (f *Device) GetToken() {
 		return
 	}
 	if debug {
-	  f.PrintObject(&resp)
+		f.PrintObject(&resp)
 	}
 
 	f.AuthToken = authToken{

--- a/f5/rule.go
+++ b/f5/rule.go
@@ -1,9 +1,9 @@
 package f5
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
-	"bytes"
 )
 
 type LBRawValues struct {


### PR DESCRIPTION
I experienced problems with go panicking in sendRequest() when it can't establish a connection. I therefore added a check in order to not presume that the error you get is an HTTP error. When I ran go fmt it seems I formatted some other stuff. Hope that's OK.
