### PR TITLE
Adding methods for getting all virtual, node, rule and pool stats in same request

### DIFF
--- a/f5/node.go
+++ b/f5/node.go
@@ -147,6 +147,20 @@ func (f *Device) ShowNodeStats(nname string) (error, *LBNodeStats) {
 
 }
 
+func (f *Device) ShowAllNodeStats() (error, *LBNodeStats) {
+
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node/stats"
+	res := LBNodeStats{}
+
+	err, _ := f.sendRequest(u, GET, nil, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+
+}
+
 func (f *Device) AddNode(body *json.RawMessage) (error, *LBNode) {
 
 	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/node"

--- a/f5/pool.go
+++ b/f5/pool.go
@@ -172,6 +172,19 @@ func (f *Device) ShowPoolStats(pname string) (error, *LBPoolStats) {
 	}
 }
 
+func (f *Device) ShowAllPoolStats() (error, *LBPoolStats) {
+
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/pool/stats"
+	res := LBPoolStats{}
+
+	err, _ := f.sendRequest(u, GET, nil, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+}
+
 func (f *Device) AddPool(body *json.RawMessage) (error, *LBPool) {
 	// we use json.RawMessage so we can modify the input file without using a struct
 	// use of a struct will send all available fields, some of which can't be modified

--- a/f5/rule.go
+++ b/f5/rule.go
@@ -105,6 +105,20 @@ func (f *Device) ShowRuleStats(rname string) (error, *LBRuleStats) {
 
 }
 
+func (f *Device) ShowAllRuleStats() (error, *LBRuleStats) {
+
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule/stats"
+	res := LBRuleStats{}
+
+	err, _ := f.sendRequest(u, GET, nil, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+
+}
+
 func (f *Device) AddRule(body *json.RawMessage) (error, *LBRule) {
 
 	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/rule"

--- a/f5/virtual.go
+++ b/f5/virtual.go
@@ -173,6 +173,19 @@ func (f *Device) ShowVirtualStats(vname string) (error, *LBVirtualStats) {
 	}
 }
 
+func (f *Device) ShowAllVirtualStats() (error, *LBVirtualStats) {
+
+	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual/stats"
+	res := LBVirtualStats{}
+
+	err, _ := f.sendRequest(u, GET, nil, &res)
+	if err != nil {
+		return err, nil
+	} else {
+		return nil, &res
+	}
+}
+
 func (f *Device) AddVirtual(virt *json.RawMessage) (error, *LBVirtual) {
 
 	u := f.Proto + "://" + f.Hostname + "/mgmt/tm/ltm/virtual"


### PR DESCRIPTION
In my application i need to get stats for all node, pools etc. I found out that you can get all stats in one single request and this brought my execution time to about 1/6 of the time it took before.
