### PR TITLE
Support certificate/key file uploads

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 )
 
 var f5Cmd = &cobra.Command{
@@ -1221,6 +1222,25 @@ var deleteStackCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		checkRequiredFlag("input")
 		deleteStack()
+	},
+}
+
+var uploadFileCmd = &cobra.Command{
+	Use:   "upload",
+	Short: "upload a file",
+	Long:  "upload a file to the f5 server",
+	Run: func(cmd *cobra.Command, args []string) {
+		filename := args[0]
+		dat, err := ioutil.ReadFile(filename)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Uploading file", filepath.Base(filename))
+		err = appliance.UploadFile(filepath.Base(filename), dat)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Done")
 	},
 }
 

--- a/f5/file.go
+++ b/f5/file.go
@@ -1,0 +1,46 @@
+package f5
+
+import (
+	"net/http"
+	"crypto/tls"
+	"fmt"
+	"errors"
+	"bytes"
+	"strconv"
+)
+
+type StatusError struct {
+
+}
+
+func (f *Device) UploadFile(filename string, data []byte) (error) {
+	//	err, res := f.sendRequest("/mgmt/shared/file-transfer/uploads/" + filename, POSTR, bytes.NewBuffer(data), resp)
+	if(len(data) > 512 * 1024) {
+		return errors.New("File size is too large, and we dont support chunked file sizes yet.")
+	}
+
+	var url string = f.Proto + "://" + f.Hostname + "/mgmt/shared/file-transfer/uploads/" + filename
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	request.SetBasicAuth(f.Username, f.Password)
+	request.Header.Set("Content-Type", "application/octet-stream")
+	request.Header.Set("Content-Range", "0-" + strconv.Itoa(len(data) - 1) + "/" + strconv.Itoa(len(data)))
+	tr := &http.Transport{
+        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+    }
+	client := &http.Client{Transport: tr}
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode > 299 || response.StatusCode < 200 {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(response.Body)
+		s := buf.String()
+		return errors.New("Unable to process request, returned status: " + response.Status + " " + s)
+	}
+	return nil
+}

--- a/f5/file.go
+++ b/f5/file.go
@@ -9,10 +9,6 @@ import (
 	"strconv"
 )
 
-type StatusError struct {
-
-}
-
 func (f *Device) UploadFile(filename string, data []byte) (error) {
 	if(len(data) > 512 * 1024) {
 		return errors.New("File size is too large, and we dont support chunked file sizes yet.")

--- a/f5/file.go
+++ b/f5/file.go
@@ -14,7 +14,6 @@ type StatusError struct {
 }
 
 func (f *Device) UploadFile(filename string, data []byte) (error) {
-	//	err, res := f.sendRequest("/mgmt/shared/file-transfer/uploads/" + filename, POSTR, bytes.NewBuffer(data), resp)
 	if(len(data) > 512 * 1024) {
 		return errors.New("File size is too large, and we dont support chunked file sizes yet.")
 	}

--- a/main.go
+++ b/main.go
@@ -182,6 +182,8 @@ func init() {
 	statsCmd.AddCommand(statsNodeCmd)
 	statsCmd.AddCommand(statsRuleCmd)
 
+	f5Cmd.AddCommand(uploadFileCmd)
+
 	// read config
 	initialiseConfig()
 


### PR DESCRIPTION
This adds the functionality to upload a crt/key to the F5 file system to then use in the fromLocalFile SSL Profile (Server/client). 

